### PR TITLE
Fix `TypeError: Cannot read properties of undefined (reading 'length')`

### DIFF
--- a/on-fail-handler.ts
+++ b/on-fail-handler.ts
@@ -30,7 +30,7 @@ export function onFailHandler(error: CypressError, runnable: Runner) {
     window.top!.document.querySelectorAll('.command-info').forEach((element) => {
       const methodSpan = element.querySelector('.command-method > span');
       const messageElement = element.querySelector('.command-message-text');
-      const errorMessage = runnable.commands[runnable.commands.length - 1]!.message;
+      const errorMessage = runnable.commands && runnable.commands[runnable.commands.length - 1].message;
       const unboldedErrorMessage = errorMessage.replaceAll('**', '');
       const unboldedExpectedValueErrorMessage = errorMessage.replace(/\*\*([^*]+)\*\*/, '$1');
       const includesErrorMessage = (message: string) => messageElement?.textContent?.includes(message);


### PR DESCRIPTION
Hi! @elaichenkov  We have found the next error when integrating the plugin with `cypress-cloud` in run mode. Here we have a fix to read the original error from the spec.


![captura error](https://github.com/elaichenkov/cypress-diff/assets/55634266/dcf8e7f8-ac0a-4aed-a53f-3e20061ab2c7)
